### PR TITLE
Add workflow lint and Renovate config

### DIFF
--- a/.github/scripts/check-codeql-sarif.mjs
+++ b/.github/scripts/check-codeql-sarif.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const sarifPath = process.argv[2];
+if (!sarifPath) {
+  console.error("Usage: node .github/scripts/check-codeql-sarif.mjs <result.sarif>");
+  process.exit(2);
+}
+
+const sarif = JSON.parse(readFileSync(sarifPath, "utf8"));
+const findings = [];
+
+for (const run of sarif.runs ?? []) {
+  const rules = new Map((run.tool?.driver?.rules ?? []).map((rule) => [rule.id, rule]));
+  for (const result of run.results ?? []) {
+    const rule = rules.get(result.ruleId);
+    const level = result.level ?? rule?.defaultConfiguration?.level ?? "warning";
+    const message = result.message?.text ?? result.message?.markdown ?? "";
+    const location = result.locations?.[0]?.physicalLocation;
+    const uri = location?.artifactLocation?.uri ?? "unknown";
+    const line = location?.region?.startLine ?? 1;
+    findings.push({ ruleId: result.ruleId ?? "unknown", level, uri, line, message });
+  }
+}
+
+if (findings.length > 0) {
+  console.error(`CodeQL produced ${findings.length} finding(s).`);
+  for (const finding of findings) {
+    console.error(`- ${finding.level} ${finding.ruleId} ${finding.uri}:${finding.line} ${finding.message}`);
+  }
+  process.exit(1);
+}
+
+console.log("No CodeQL findings.");

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,17 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Install pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -22,14 +26,19 @@ jobs:
           node-version: 24
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Check formatting
         run: pnpm run format
 
   typecheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Install pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -37,14 +46,19 @@ jobs:
           node-version: 24
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Run type checking
         run: pnpm run build
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Install pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -52,6 +66,6 @@ jobs:
           node-version: 24
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Run tests
         run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,60 +16,69 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
-      id-token: write  # For npm provenance
+      id-token: write # For npm provenance
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      
+          persist-credentials: false
+
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org/'
-      
+
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-      
+
       - name: Install dependencies
-        run: pnpm install
-      
+        run: pnpm install --frozen-lockfile
+
       - name: Configure Git
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          gh auth setup-git --hostname github.com --force
           git config --local user.name "GitHub Actions"
           git config --local user.email "github-actions@github.com"
-      
+
       - name: Bump version
         id: version
+        env:
+          VERSION_TYPE: ${{ github.event.inputs.version_type }}
         run: |
+          set -euo pipefail
+
           # Get current version
           CURRENT_VERSION=$(node -p "require('./package.json').version")
-          echo "Current version: $CURRENT_VERSION"
-          
+          echo "Current version: ${CURRENT_VERSION}"
+
           # Bump version using npm version
-          npm version ${{ github.event.inputs.version_type }} --no-git-tag-version
-          
+          npm version "${VERSION_TYPE}" --no-git-tag-version
+
           # Get new version
           NEW_VERSION=$(node -p "require('./package.json').version")
-          echo "New version: $NEW_VERSION"
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-      
+          echo "New version: ${NEW_VERSION}"
+          echo "new_version=${NEW_VERSION}" >> "${GITHUB_OUTPUT}"
+
       - name: Commit changes
         run: |
           git add package.json
           git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }}"
           git push
-      
+
       - name: Create Release
         id: create_release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           git tag v${{ steps.version.outputs.new_version }}
           git push --tags
           gh release create v${{ steps.version.outputs.new_version }} \
             --generate-notes
-      
+
       # Publish to npm
       - name: Publish to npm
         run: npm publish --provenance --access public

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,187 @@
+name: workflow-lint
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/scripts/**"
+      - ".github/ghalint.y*ml"
+      - ".github/zizmor.y*ml"
+      - ".pinact.y*ml"
+      - "zizmor.y*ml"
+    types:
+      - opened
+      - reopened
+      - synchronize
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  pinact:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Download pinact
+        env:
+          # renovate: datasource=github-releases depName=suzuki-shunsuke/pinact
+          PINACT_VERSION: v4.1.0
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          archive="pinact_linux_amd64.tar.gz"
+          curl -sSfL -H "Authorization: token ${GITHUB_TOKEN}" -o "/tmp/${archive}" "https://github.com/suzuki-shunsuke/pinact/releases/download/${PINACT_VERSION}/${archive}"
+          curl -sSfL -H "Authorization: token ${GITHUB_TOKEN}" -o /tmp/pinact_checksums.txt "https://github.com/suzuki-shunsuke/pinact/releases/download/${PINACT_VERSION}/pinact_${PINACT_VERSION#v}_checksums.txt"
+          (cd /tmp && grep "  ${archive}$" pinact_checksums.txt | sha256sum -c -)
+          tar -xzf "/tmp/${archive}" -C /tmp
+          sudo install -m 0755 /tmp/pinact /usr/local/bin/pinact
+          pinact version
+        shell: bash
+
+      - name: Check pinned action refs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PINACT_GITHUB_TOKEN: ${{ github.token }}
+        run: pinact run --check
+        shell: bash
+
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Download actionlint
+        id: get_actionlint
+        env:
+          # renovate: datasource=github-releases depName=rhysd/actionlint
+          ACTIONLINT_VERSION: v1.7.12
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          curl -sSfL -H "Authorization: token ${GITHUB_TOKEN}" -o /tmp/download-actionlint.bash "https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_VERSION}/scripts/download-actionlint.bash"
+          bash /tmp/download-actionlint.bash "${ACTIONLINT_VERSION#v}"
+        shell: bash
+
+      - name: Check workflow files
+        env:
+          ACTIONLINT_EXECUTABLE: ${{ steps.get_actionlint.outputs.executable }}
+        run: |
+          "${ACTIONLINT_EXECUTABLE}" -color
+        shell: bash
+
+  ghalint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Download ghalint
+        env:
+          # renovate: datasource=github-releases depName=suzuki-shunsuke/ghalint
+          GHALINT_VERSION: v1.5.6
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          archive="ghalint_${GHALINT_VERSION#v}_linux_amd64.tar.gz"
+          curl -sSfL -H "Authorization: token ${GITHUB_TOKEN}" -o "/tmp/${archive}" "https://github.com/suzuki-shunsuke/ghalint/releases/download/${GHALINT_VERSION}/${archive}"
+          curl -sSfL -H "Authorization: token ${GITHUB_TOKEN}" -o /tmp/ghalint_checksums.txt "https://github.com/suzuki-shunsuke/ghalint/releases/download/${GHALINT_VERSION}/ghalint_${GHALINT_VERSION#v}_checksums.txt"
+          (cd /tmp && grep "  ${archive}$" ghalint_checksums.txt | sha256sum -c -)
+          tar -xzf "/tmp/${archive}" -C /tmp
+          sudo install -m 0755 /tmp/ghalint /usr/local/bin/ghalint
+          ghalint version
+        shell: bash
+
+      - name: Check workflow files
+        run: ghalint run
+        shell: bash
+
+      - name: Run ghalint for composite actions
+        run: ghalint run-action
+        shell: bash
+
+  zizmor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor security check
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          inputs: .github/workflows/
+          min-severity: medium
+          token: ${{ github.token }}
+          advanced-security: false
+          annotations: true
+          # renovate: datasource=github-releases depName=zizmorcore/zizmor
+          version: v1.25.2
+
+  codeql-actions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        with:
+          languages: actions
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        id: analyze
+        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        with:
+          category: /language:actions
+          output: ../results
+          upload: never
+          upload-database: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Check CodeQL findings
+        env:
+          SARIF_DIR: ${{ steps.analyze.outputs.sarif-output }}
+        run: |
+          set -euo pipefail
+
+          sarif_file="$(find "${SARIF_DIR}" -name "*.sarif" -print -quit)"
+          if [[ -z "${sarif_file}" ]]; then
+            echo "No CodeQL SARIF file was generated." >&2
+            exit 1
+          fi
+
+          node .github/scripts/check-codeql-sarif.mjs "${sarif_file}"
+        shell: bash

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/main/json-schema/pinact.json
+version: 3
+min_age:
+  value: 7
+  always: true

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:best-practices", "helpers:pinGitHubActionDigests"],
+  "minimumReleaseAge": "7 days",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$/",
+        "/(^|/)action\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
+      ]
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Automerge minor, patch, digest, and pinDigest GitHub Actions updates after a 7 day minimum release age",
+      "groupName": "github-actions (non-major)",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pinDigest"],
+      "automerge": true,
+      "automergeType": "pr",
+      "minimumReleaseAge": "7 days"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a workflow-lint workflow with pinact, actionlint, ghalint, zizmor, and CodeQL Actions analysis
- add .pinact.yaml and renovate.json5 for 7 day release age, GitHub Actions digest pinning, and workflow tool version updates
- harden existing CI/release workflows with job permissions, timeouts, checkout persist-credentials: false, and frozen pnpm installs

## Local checks
- GITHUB_TOKEN=$(gh auth token) PINACT_GITHUB_TOKEN=$(gh auth token) pinact run --check
- actionlint -color
- ghalint run
- ghalint run-action
- uvx zizmor .github/workflows --min-severity medium
- npx --yes --package renovate -- renovate-config-validator --no-global renovate.json5
- pnpm install --frozen-lockfile
- pnpm run format
- pnpm run build
- pnpm test
- git diff --cached --check

## Notes
- No replacement-catalog action was safely replaceable here. Release creation already uses gh release create.
- pnpm run lint currently fails on pre-existing unused imports in test files; this PR does not change those files.